### PR TITLE
Fill in module README placeholders

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -1,44 +1,30 @@
-# Src
+# Source Package
 
 ## Overview
+The `src` directory contains the Python backend for WFM Enterprise.  Major packages include:
 
-Module description to be added.
+- **`api`** – FastAPI application exposing REST and WebSocket endpoints.
+- **`algorithms`** – Erlang C calculations, ML forecasting and schedule optimisation code.
+- **`database`** – SQLAlchemy models and helpers for PostgreSQL.
+- **`websocket`** – real‑time server used by the UI for live updates.
 
 ## Features
-
-- Feature 1
-- Feature 2
-- Feature 3
-
-## Installation
-
-```bash
-# No additional installation required
-```
+- Modular architecture for easy extension
+- Type hinted codebase with Pydantic models
+- Compatible with the UI and automated test suites
 
 ## Usage
-
-# Usage examples to be added
-
-## API Reference
-
-# API reference to be added
-
-## Configuration
-
-# Configuration details to be added
+Start the development server:
+```bash
+python -m uvicorn src.api.main:app --reload
+```
+See the individual sub‑module READMEs for more details.
 
 ## Testing
-
 ```bash
-pytest tests/src/
+pytest tests/
 ```
 
-## Contributing
-
-See the main project [Contributing Guidelines](../../CONTRIBUTING.md).
-
 ## Related Documentation
-
-- [Main README](../../README.md)
-- [Technical Documentation](../../TECHNICAL_DOCS.md)
+- [Project README](../README.md)
+- [API Documentation](../docs/api/api_reference.md)

--- a/src/algorithms/README.md
+++ b/src/algorithms/README.md
@@ -1,44 +1,27 @@
 # Algorithms
 
 ## Overview
-
-Algorithm implementation module
+Collection of calculation engines used by the WFM Enterprise platform. Algorithms
+include Erlang C staffing, machine learning forecasting and optimisation routines.
 
 ## Features
-
-- Feature 1
-- Feature 2
-- Feature 3
-
-## Installation
-
-```bash
-# No additional installation required
-```
+- Pure Python implementations with NumPy/SciPy
+- Pluggable architecture for new strategies
+- Shared utilities for benchmarking
 
 ## Usage
+Example Erlang C call:
+```python
+from src.algorithms.core.erlang_c import erlang_c
 
-# Usage examples to be added
-
-## API Reference
-
-# API reference to be added
-
-## Configuration
-
-# Configuration details to be added
-
-## Testing
-
-```bash
-pytest tests/algorithms/algorithms/
+agents = erlang_c(calls=120, aht=300, target_sl=0.8)
 ```
 
-## Contributing
-
-See the main project [Contributing Guidelines](../../CONTRIBUTING.md).
+## Testing
+```bash
+pytest tests/algorithms/
+```
 
 ## Related Documentation
-
-- [Main README](../../README.md)
-- [Technical Documentation](../../TECHNICAL_DOCS.md)
+- [Erlang C Strategy](../../docs/ERLANG_C_OPTIMIZATION_STRATEGY.md)
+- [Project README](../README.md)

--- a/src/algorithms/core/README.md
+++ b/src/algorithms/core/README.md
@@ -1,44 +1,26 @@
-# Core
+# Core Algorithms
 
 ## Overview
-
-Algorithm implementation module
+Low-level building blocks for more advanced scheduling and forecasting algorithms.
+Includes Erlang C probability functions and helper utilities.
 
 ## Features
-
-- Feature 1
-- Feature 2
-- Feature 3
-
-## Installation
-
-```bash
-# No additional installation required
-```
+- Optimised numerical routines
+- Shared data structures used across algorithms
+- Unit tested for accuracy
 
 ## Usage
+```python
+from src.algorithms.core.erlang_c import erlang_c_probability
 
-# Usage examples to be added
-
-## API Reference
-
-# API reference to be added
-
-## Configuration
-
-# Configuration details to be added
+p = erlang_c_probability(agents=10, traffic=7.2)
+```
 
 ## Testing
-
 ```bash
 pytest tests/algorithms/core/
 ```
 
-## Contributing
-
-See the main project [Contributing Guidelines](../../CONTRIBUTING.md).
-
 ## Related Documentation
-
-- [Main README](../../README.md)
-- [Technical Documentation](../../TECHNICAL_DOCS.md)
+- [Algorithms README](../README.md)
+- [Project README](../../README.md)

--- a/src/algorithms/ml/README.md
+++ b/src/algorithms/ml/README.md
@@ -1,44 +1,26 @@
-# Ml
+# ML Algorithms
 
 ## Overview
-
-Algorithm implementation module
+Machine learning models used for workload forecasting. Implemented with
+scikit‑learn and NumPy.
 
 ## Features
-
-- Feature 1
-- Feature 2
-- Feature 3
-
-## Installation
-
-```bash
-# No additional installation required
-```
+- Support for multiple regression models
+- Tools for time series preprocessing
+- Benchmark utilities for accuracy comparison
 
 ## Usage
+```python
+from src.algorithms.ml.forecast import forecast_demand
 
-# Usage examples to be added
-
-## API Reference
-
-# API reference to be added
-
-## Configuration
-
-# Configuration details to be added
+y = forecast_demand(history)
+```
 
 ## Testing
-
 ```bash
 pytest tests/algorithms/ml/
 ```
 
-## Contributing
-
-See the main project [Contributing Guidelines](../../CONTRIBUTING.md).
-
 ## Related Documentation
-
-- [Main README](../../README.md)
-- [Technical Documentation](../../TECHNICAL_DOCS.md)
+- [Algorithms README](../README.md)
+- [Forecasting API Guide](../../../docs/FORECASTING_API_IMPLEMENTATION_SUMMARY.md)

--- a/src/algorithms/optimization/README.md
+++ b/src/algorithms/optimization/README.md
@@ -1,44 +1,26 @@
-# Optimization
+# Optimization Algorithms
 
 ## Overview
-
-Algorithm implementation module
+Routines for schedule and resource optimisation. Implemented using linear
+programming and heuristic approaches.
 
 ## Features
-
-- Feature 1
-- Feature 2
-- Feature 3
-
-## Installation
-
-```bash
-# No additional installation required
-```
+- Mixed Integer Programming models
+- Heuristics for large scale problems
+- Interfaces for plugging in custom constraints
 
 ## Usage
+```python
+from src.algorithms.optimization.scheduler import optimize_schedule
 
-# Usage examples to be added
-
-## API Reference
-
-# API reference to be added
-
-## Configuration
-
-# Configuration details to be added
+result = optimize_schedule(data)
+```
 
 ## Testing
-
 ```bash
 pytest tests/algorithms/optimization/
 ```
 
-## Contributing
-
-See the main project [Contributing Guidelines](../../CONTRIBUTING.md).
-
 ## Related Documentation
-
-- [Main README](../../README.md)
-- [Technical Documentation](../../TECHNICAL_DOCS.md)
+- [Algorithms README](../README.md)
+- [Optimization API Summary](../../../docs/INTEGRATED_WORKFORCE_OPTIMIZATION_IMPLEMENTATION_SUMMARY.md)

--- a/src/api/services/README.md
+++ b/src/api/services/README.md
@@ -1,44 +1,27 @@
 # Services
 
 ## Overview
-
-API endpoint implementation
+Business logic layer used by the FastAPI endpoints. Services coordinate database
+access and algorithm execution so handlers remain thin.
 
 ## Features
-
-- Feature 1
-- Feature 2
-- Feature 3
-
-## Installation
-
-```bash
-# No additional installation required
-```
+- Asynchronous database operations via SQLAlchemy
+- Input validation with Pydantic models
+- Integration with the algorithm modules
 
 ## Usage
+Example of calling a service from an endpoint:
+```python
+from src.api.services.schedule_service import create_schedule
 
-# Usage examples to be added
-
-## API Reference
-
-# API reference to be added
-
-## Configuration
-
-# Configuration details to be added
+schedule = await create_schedule(request_data)
+```
 
 ## Testing
-
 ```bash
 pytest tests/api/services/
 ```
 
-## Contributing
-
-See the main project [Contributing Guidelines](../../CONTRIBUTING.md).
-
 ## Related Documentation
-
-- [Main README](../../README.md)
-- [Technical Documentation](../../TECHNICAL_DOCS.md)
+- [API README](../README.md)
+- [Project README](../../README.md)

--- a/src/api/v1/endpoints/README.md
+++ b/src/api/v1/endpoints/README.md
@@ -1,44 +1,26 @@
 # Endpoints
 
 ## Overview
-
-API endpoint implementation
+FastAPI route functions for version 1 of the public API. Each file groups
+endpoints by domain and uses services to perform business logic.
 
 ## Features
-
-- Feature 1
-- Feature 2
-- Feature 3
-
-## Installation
-
-```bash
-# No additional installation required
-```
+- Organized routing with dependency injection
+- Automatic OpenAPI documentation
+- Supports both REST and WebSocket handlers
 
 ## Usage
-
-# Usage examples to be added
-
-## API Reference
-
-# API reference to be added
-
-## Configuration
-
-# Configuration details to be added
+Run the API server and access the docs:
+```bash
+uvicorn src.api.main:app --reload
+# Visit http://localhost:8000/docs
+```
 
 ## Testing
-
 ```bash
 pytest tests/api/endpoints/
 ```
 
-## Contributing
-
-See the main project [Contributing Guidelines](../../CONTRIBUTING.md).
-
 ## Related Documentation
-
-- [Main README](../../README.md)
-- [Technical Documentation](../../TECHNICAL_DOCS.md)
+- [API Reference](../../../docs/api/api_reference.md)
+- [Services README](../services/README.md)

--- a/src/database/README.md
+++ b/src/database/README.md
@@ -1,44 +1,29 @@
 # Database
 
 ## Overview
-
-Module description to be added.
+Database access layer built with SQLAlchemy. It defines ORM models,
+initialization helpers and migration scripts for PostgreSQL.
 
 ## Features
-
-- Feature 1
-- Feature 2
-- Feature 3
-
-## Installation
-
-```bash
-# No additional installation required
-```
+- Centralised session handling
+- Alembic migrations for schema changes
+- Utility functions for common queries
 
 ## Usage
+Create a session and query models:
+```python
+from src.database.session import SessionLocal
+from src.database import models
 
-# Usage examples to be added
-
-## API Reference
-
-# API reference to be added
-
-## Configuration
-
-# Configuration details to be added
+with SessionLocal() as session:
+    users = session.query(models.Employee).all()
+```
 
 ## Testing
-
 ```bash
 pytest tests/database/
 ```
 
-## Contributing
-
-See the main project [Contributing Guidelines](../../CONTRIBUTING.md).
-
 ## Related Documentation
-
-- [Main README](../../README.md)
-- [Technical Documentation](../../TECHNICAL_DOCS.md)
+- [Database Schema Docs](../../docs/architecture/database.md)
+- [Project README](../../README.md)

--- a/src/database/procedures/README.md
+++ b/src/database/procedures/README.md
@@ -1,44 +1,27 @@
 # Procedures
 
 ## Overview
-
-Module description to be added.
+SQL stored procedures and helper functions used by the application. They are
+wrapped by Python utilities for ease of use.
 
 ## Features
-
-- Feature 1
-- Feature 2
-- Feature 3
-
-## Installation
-
-```bash
-# No additional installation required
-```
+- Parameterised SQL scripts
+- Convenience wrappers for calling procedures
+- Version controlled alongside the codebase
 
 ## Usage
+Example of executing a procedure:
+```python
+from src.database.procedures import sync_work_time
 
-# Usage examples to be added
-
-## API Reference
-
-# API reference to be added
-
-## Configuration
-
-# Configuration details to be added
+await sync_work_time(start_date="2024-01-01", end_date="2024-01-31")
+```
 
 ## Testing
-
 ```bash
 pytest tests/procedures/
 ```
 
-## Contributing
-
-See the main project [Contributing Guidelines](../../CONTRIBUTING.md).
-
 ## Related Documentation
-
-- [Main README](../../README.md)
-- [Technical Documentation](../../TECHNICAL_DOCS.md)
+- [Database README](../README.md)
+- [Architecture Docs](../../../docs/architecture/database.md)

--- a/src/database/schemas/README.md
+++ b/src/database/schemas/README.md
@@ -1,44 +1,29 @@
 # Schemas
 
 ## Overview
-
-Module description to be added.
+Pydantic models describing the data structures stored in the database and
+exchanged by the API.
 
 ## Features
-
-- Feature 1
-- Feature 2
-- Feature 3
-
-## Installation
-
-```bash
-# No additional installation required
-```
+- Typed request and response models
+- Reuse across API and services
+- Validation of incoming data
 
 ## Usage
+Example schema definition:
+```python
+from pydantic import BaseModel
 
-# Usage examples to be added
-
-## API Reference
-
-# API reference to be added
-
-## Configuration
-
-# Configuration details to be added
+class EmployeeCreate(BaseModel):
+    name: str
+    role: str
+```
 
 ## Testing
-
 ```bash
 pytest tests/schemas/
 ```
 
-## Contributing
-
-See the main project [Contributing Guidelines](../../CONTRIBUTING.md).
-
 ## Related Documentation
-
-- [Main README](../../README.md)
-- [Technical Documentation](../../TECHNICAL_DOCS.md)
+- [Database README](../README.md)
+- [API Reference](../../../docs/api/api_reference.md)

--- a/src/ui/src/modules/README.md
+++ b/src/ui/src/modules/README.md
@@ -1,44 +1,25 @@
 # Modules
 
 ## Overview
-
-User interface module
+Reusable React modules that make up the WFM Enterprise UI. Each module contains
+components, state management and routing for a specific feature area.
 
 ## Features
-
-- Feature 1
-- Feature 2
-- Feature 3
-
-## Installation
-
-```bash
-# No additional installation required
-```
+- Isolated code for features such as reporting or scheduling
+- Written in TypeScript with Tailwind styles
+- Can be lazy loaded to reduce bundle size
 
 ## Usage
-
-# Usage examples to be added
-
-## API Reference
-
-# API reference to be added
-
-## Configuration
-
-# Configuration details to be added
+Import a module in `App.tsx`:
+```tsx
+import { ReportsModule } from './modules/reports-analytics';
+```
 
 ## Testing
-
 ```bash
 npm test
 ```
 
-## Contributing
-
-See the main project [Contributing Guidelines](../../CONTRIBUTING.md).
-
 ## Related Documentation
-
-- [Main README](../../README.md)
-- [Technical Documentation](../../TECHNICAL_DOCS.md)
+- [UI README](../../README.md)
+- [Project README](../../../README.md)

--- a/src/websocket/README.md
+++ b/src/websocket/README.md
@@ -1,44 +1,30 @@
-# Websocket
+# WebSocket
 
 ## Overview
-
-Module description to be added.
+Real-time communication layer built on top of FastAPI's WebSocket support. It is
+used by the UI to receive schedule updates and live metrics.
 
 ## Features
-
-- Feature 1
-- Feature 2
-- Feature 3
-
-## Installation
-
-```bash
-# No additional installation required
-```
+- Connection management with authentication
+- Event dispatcher for broadcasting messages
+- Typed message definitions
 
 ## Usage
-
-# Usage examples to be added
-
-## API Reference
-
-# API reference to be added
-
-## Configuration
-
-# Configuration details to be added
+Start the server and connect from the browser:
+```bash
+uvicorn src.api.main:app --reload
+```
+In JavaScript:
+```javascript
+const ws = new WebSocket('ws://localhost:8000/ws');
+ws.onmessage = e => console.log(e.data);
+```
 
 ## Testing
-
 ```bash
 pytest tests/websocket/
 ```
 
-## Contributing
-
-See the main project [Contributing Guidelines](../../CONTRIBUTING.md).
-
 ## Related Documentation
-
-- [Main README](../../README.md)
-- [Technical Documentation](../../TECHNICAL_DOCS.md)
+- [API README](../api/README.md)
+- [Project README](../README.md)

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,44 +1,24 @@
 # Tests
 
 ## Overview
-
-Module description to be added.
+Contains unit, integration and end-to-end tests for all modules. The test suite
+ensures API compatibility and verifies algorithm performance.
 
 ## Features
-
-- Feature 1
-- Feature 2
-- Feature 3
-
-## Installation
-
-```bash
-# No additional installation required
-```
+- Pytest based unit tests
+- BDD scenarios and SQL fixtures
+- Playwright end-to-end tests under `e2e-tests/`
 
 ## Usage
-
-# Usage examples to be added
-
-## API Reference
-
-# API reference to be added
-
-## Configuration
-
-# Configuration details to be added
-
-## Testing
-
+Run all tests:
 ```bash
-pytest tests/tests/
+pytest tests/
+```
+Run a specific suite:
+```bash
+pytest tests/algorithms/
 ```
 
-## Contributing
-
-See the main project [Contributing Guidelines](../../CONTRIBUTING.md).
-
 ## Related Documentation
-
-- [Main README](../../README.md)
-- [Technical Documentation](../../TECHNICAL_DOCS.md)
+- [Testing Guide](../docs/api/testing_guide.md)
+- [Project README](../README.md)


### PR DESCRIPTION
## Summary
- replace placeholder descriptions in all module README files
- add usage examples and testing instructions

## Testing
- `pip install pytest-cov`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_688b511d4a7483228ad6c92114ad906e